### PR TITLE
fix: prevent InvalidTokenError when accessing /home without login

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,12 +13,14 @@ const Login = () => {
   useEffect(() => {
       try{
         const token = localStorage.getItem("ACCESS_TOKEN");
-        const decoded = jwtDecode(token);
-        const tokenExpiration = decoded.exp;
-        const now = Date.now() / 1000;
-        
-        if (token && tokenExpiration > now) {
+        if (token) {
+          const decoded = jwtDecode(token);
+          const tokenExpiration = decoded.exp;
+          const now = Date.now() / 1000;
+          
+          if (tokenExpiration > now) {
             navigate("/home");
+          }
         }
       } catch(err){
         console.error(err);

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -13,12 +13,14 @@ const Signup = () => {
   useEffect(() => {
       try{
         const token = localStorage.getItem("ACCESS_TOKEN");
-        const decoded = jwtDecode(token);
-        const tokenExpiration = decoded.exp;
-        const now = Date.now() / 1000;
-        
-        if (token && tokenExpiration > now) {
-            navigate("/home");
+        if (token) {
+          const decoded = jwtDecode(token);
+          const tokenExpiration = decoded.exp;
+          const now = Date.now() / 1000;
+          
+          if (token && tokenExpiration > now) {
+              navigate("/home");
+          }
         }
       } catch(err){
         console.error(err);


### PR DESCRIPTION
## Description
- Fixes InvalidTokenError when users directly visit `/home` without being logged in.
- Occurs because `jwtDecode()` is called on `null` token from localStorage
- Added token existence check before calling `jwtDecode()`

## Issue
[#3](https://github.com/mdgspace/vulnora/issues/3)